### PR TITLE
plugin: add DNS names

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -568,6 +568,15 @@ func awsInstanceToHost(instance *ec2.Instance) (*pb.ListHostsResponseHost, error
 			return nil, errors.New("response integrity error: interface entry is nil")
 		}
 
+		// Populate default IP addresses/DNS name similar to how we do
+		// for the entire instance.
+		if aws.StringValue(iface.PrivateIpAddress) != "" && !stringInSlice(result.IpAddresses, aws.StringValue(iface.PrivateIpAddress)) {
+			result.IpAddresses = append(result.IpAddresses, aws.StringValue(iface.PrivateIpAddress))
+		}
+		if aws.StringValue(iface.PrivateDnsName) != "" && !stringInSlice(result.DnsNames, aws.StringValue(iface.PrivateDnsName)) {
+			result.DnsNames = append(result.DnsNames, aws.StringValue(iface.PrivateDnsName))
+		}
+
 		// Iterate through the private IP addresses and log the
 		// information.
 		for _, addr := range iface.PrivateIpAddresses {
@@ -575,31 +584,20 @@ func awsInstanceToHost(instance *ec2.Instance) (*pb.ListHostsResponseHost, error
 				return nil, errors.New("response integrity error: interface address entry is nil")
 			}
 
-			// Check to see if the PrivateIpAddress/PrivateDnsName fields
-			// match the ones reported at the top-level of the instance.
-			// If they don't, add them.
-			if aws.StringValue(addr.PrivateIpAddress) != "" {
-				if aws.StringValue(instance.PrivateIpAddress) != aws.StringValue(addr.PrivateIpAddress) {
-					result.IpAddresses = append(result.IpAddresses, aws.StringValue(addr.PrivateIpAddress))
-				}
+			// Add private address/dns name if they have not been added yet
+			if aws.StringValue(addr.PrivateIpAddress) != "" && !stringInSlice(result.IpAddresses, aws.StringValue(addr.PrivateIpAddress)) {
+				result.IpAddresses = append(result.IpAddresses, aws.StringValue(addr.PrivateIpAddress))
 			}
-			if aws.StringValue(addr.PrivateDnsName) != "" {
-				if aws.StringValue(instance.PrivateDnsName) != aws.StringValue(addr.PrivateDnsName) {
-					result.DnsNames = append(result.DnsNames, aws.StringValue(addr.PrivateDnsName))
-				}
+			if aws.StringValue(addr.PrivateDnsName) != "" && !stringInSlice(result.DnsNames, aws.StringValue(addr.PrivateDnsName)) {
+				result.DnsNames = append(result.DnsNames, aws.StringValue(addr.PrivateDnsName))
 			}
 
-			// Do the same for the top-level public IP address/DNS name and
-			// the public association on the interface.
-			if addr.Association != nil && aws.StringValue(addr.Association.PublicIp) != "" {
-				if aws.StringValue(instance.PublicIpAddress) != aws.StringValue(addr.Association.PublicIp) {
-					result.IpAddresses = append(result.IpAddresses, aws.StringValue(addr.Association.PublicIp))
-				}
+			// Add public address/dns name if they have not been added yet
+			if addr.Association != nil && aws.StringValue(addr.Association.PublicIp) != "" && !stringInSlice(result.IpAddresses, aws.StringValue(addr.Association.PublicIp)) {
+				result.IpAddresses = append(result.IpAddresses, aws.StringValue(addr.Association.PublicIp))
 			}
-			if addr.Association != nil && aws.StringValue(addr.Association.PublicDnsName) != "" {
-				if aws.StringValue(instance.PublicDnsName) != aws.StringValue(addr.Association.PublicDnsName) {
-					result.DnsNames = append(result.DnsNames, aws.StringValue(addr.Association.PublicDnsName))
-				}
+			if addr.Association != nil && aws.StringValue(addr.Association.PublicDnsName) != "" && !stringInSlice(result.DnsNames, aws.StringValue(addr.Association.PublicDnsName)) {
+				result.DnsNames = append(result.DnsNames, aws.StringValue(addr.Association.PublicDnsName))
 			}
 		}
 
@@ -617,4 +615,14 @@ func awsInstanceToHost(instance *ec2.Instance) (*pb.ListHostsResponseHost, error
 
 	// Done
 	return result, nil
+}
+
+func stringInSlice(s []string, x string) bool {
+	for _, y := range s {
+		if x == y {
+			return true
+		}
+	}
+
+	return false
 }

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -1385,6 +1385,8 @@ func TestAwsInstanceToHost(t *testing.T) {
 				PublicDnsName:    aws.String("test.example.com"),
 				NetworkInterfaces: []*ec2.InstanceNetworkInterface{
 					&ec2.InstanceNetworkInterface{
+						PrivateIpAddress: aws.String("10.0.0.1"),
+						PrivateDnsName:   aws.String("test.example.internal"),
 						PrivateIpAddresses: []*ec2.InstancePrivateIpAddress{
 							&ec2.InstancePrivateIpAddress{
 								Association: &ec2.InstanceNetworkInterfaceAssociation{
@@ -1412,6 +1414,8 @@ func TestAwsInstanceToHost(t *testing.T) {
 				PrivateDnsName:   aws.String("test.example.internal"),
 				NetworkInterfaces: []*ec2.InstanceNetworkInterface{
 					&ec2.InstanceNetworkInterface{
+						PrivateIpAddress: aws.String("10.0.0.1"),
+						PrivateDnsName:   aws.String("test.example.internal"),
 						PrivateIpAddresses: []*ec2.InstancePrivateIpAddress{
 							&ec2.InstancePrivateIpAddress{
 								PrivateIpAddress: aws.String("10.0.0.1"),
@@ -1437,6 +1441,8 @@ func TestAwsInstanceToHost(t *testing.T) {
 				PublicDnsName:    aws.String("test.example.com"),
 				NetworkInterfaces: []*ec2.InstanceNetworkInterface{
 					&ec2.InstanceNetworkInterface{
+						PrivateIpAddress: aws.String("10.0.0.2"),
+						PrivateDnsName:   aws.String("test2.example.internal"),
 						PrivateIpAddresses: []*ec2.InstancePrivateIpAddress{
 							&ec2.InstancePrivateIpAddress{
 								PrivateIpAddress: aws.String("10.0.0.2"),
@@ -1445,6 +1451,8 @@ func TestAwsInstanceToHost(t *testing.T) {
 						},
 					},
 					&ec2.InstanceNetworkInterface{
+						PrivateIpAddress: aws.String("10.0.0.1"),
+						PrivateDnsName:   aws.String("test.example.internal"),
 						PrivateIpAddresses: []*ec2.InstancePrivateIpAddress{
 							&ec2.InstancePrivateIpAddress{
 								Association: &ec2.InstanceNetworkInterfaceAssociation{
@@ -1474,6 +1482,8 @@ func TestAwsInstanceToHost(t *testing.T) {
 				PublicDnsName:    aws.String("test.example.com"),
 				NetworkInterfaces: []*ec2.InstanceNetworkInterface{
 					&ec2.InstanceNetworkInterface{
+						PrivateIpAddress: aws.String("10.0.0.2"),
+						PrivateDnsName:   aws.String("test2.example.internal"),
 						PrivateIpAddresses: []*ec2.InstancePrivateIpAddress{
 							&ec2.InstancePrivateIpAddress{
 								Association: &ec2.InstanceNetworkInterfaceAssociation{
@@ -1486,6 +1496,8 @@ func TestAwsInstanceToHost(t *testing.T) {
 						},
 					},
 					&ec2.InstanceNetworkInterface{
+						PrivateIpAddress: aws.String("10.0.0.1"),
+						PrivateDnsName:   aws.String("test.example.internal"),
 						PrivateIpAddresses: []*ec2.InstancePrivateIpAddress{
 							&ec2.InstancePrivateIpAddress{
 								Association: &ec2.InstanceNetworkInterfaceAssociation{
@@ -1515,6 +1527,8 @@ func TestAwsInstanceToHost(t *testing.T) {
 				PublicDnsName:    aws.String("test.example.com"),
 				NetworkInterfaces: []*ec2.InstanceNetworkInterface{
 					&ec2.InstanceNetworkInterface{
+						PrivateIpAddress: aws.String("10.0.0.1"),
+						PrivateDnsName:   aws.String("test.example.internal"),
 						PrivateIpAddresses: []*ec2.InstancePrivateIpAddress{
 							&ec2.InstancePrivateIpAddress{
 								Association: &ec2.InstanceNetworkInterfaceAssociation{
@@ -1548,6 +1562,7 @@ func TestAwsInstanceToHost(t *testing.T) {
 				PublicDnsName:    aws.String("test.example.com"),
 				NetworkInterfaces: []*ec2.InstanceNetworkInterface{
 					&ec2.InstanceNetworkInterface{
+						PrivateIpAddress: aws.String("10.0.0.1"),
 						PrivateIpAddresses: []*ec2.InstancePrivateIpAddress{
 							&ec2.InstancePrivateIpAddress{
 								Association: &ec2.InstanceNetworkInterfaceAssociation{

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -1380,15 +1380,19 @@ func TestAwsInstanceToHost(t *testing.T) {
 			instance: &ec2.Instance{
 				InstanceId:       aws.String("foobar"),
 				PrivateIpAddress: aws.String("10.0.0.1"),
+				PrivateDnsName:   aws.String("test.example.internal"),
 				PublicIpAddress:  aws.String("1.1.1.1"),
+				PublicDnsName:    aws.String("test.example.com"),
 				NetworkInterfaces: []*ec2.InstanceNetworkInterface{
 					&ec2.InstanceNetworkInterface{
 						PrivateIpAddresses: []*ec2.InstancePrivateIpAddress{
 							&ec2.InstancePrivateIpAddress{
 								Association: &ec2.InstanceNetworkInterfaceAssociation{
-									PublicIp: aws.String("1.1.1.1"),
+									PublicIp:      aws.String("1.1.1.1"),
+									PublicDnsName: aws.String("test.example.com"),
 								},
 								PrivateIpAddress: aws.String("10.0.0.1"),
+								PrivateDnsName:   aws.String("test.example.internal"),
 							},
 						},
 					},
@@ -1397,6 +1401,7 @@ func TestAwsInstanceToHost(t *testing.T) {
 			expected: &pb.ListHostsResponseHost{
 				ExternalId:  "foobar",
 				IpAddresses: []string{"10.0.0.1", "1.1.1.1"},
+				DnsNames:    []string{"test.example.internal", "test.example.com"},
 			},
 		},
 		{
@@ -1404,11 +1409,13 @@ func TestAwsInstanceToHost(t *testing.T) {
 			instance: &ec2.Instance{
 				InstanceId:       aws.String("foobar"),
 				PrivateIpAddress: aws.String("10.0.0.1"),
+				PrivateDnsName:   aws.String("test.example.internal"),
 				NetworkInterfaces: []*ec2.InstanceNetworkInterface{
 					&ec2.InstanceNetworkInterface{
 						PrivateIpAddresses: []*ec2.InstancePrivateIpAddress{
 							&ec2.InstancePrivateIpAddress{
 								PrivateIpAddress: aws.String("10.0.0.1"),
+								PrivateDnsName:   aws.String("test.example.internal"),
 							},
 						},
 					},
@@ -1417,6 +1424,7 @@ func TestAwsInstanceToHost(t *testing.T) {
 			expected: &pb.ListHostsResponseHost{
 				ExternalId:  "foobar",
 				IpAddresses: []string{"10.0.0.1"},
+				DnsNames:    []string{"test.example.internal"},
 			},
 		},
 		{
@@ -1424,12 +1432,15 @@ func TestAwsInstanceToHost(t *testing.T) {
 			instance: &ec2.Instance{
 				InstanceId:       aws.String("foobar"),
 				PrivateIpAddress: aws.String("10.0.0.1"),
+				PrivateDnsName:   aws.String("test.example.internal"),
 				PublicIpAddress:  aws.String("1.1.1.1"),
+				PublicDnsName:    aws.String("test.example.com"),
 				NetworkInterfaces: []*ec2.InstanceNetworkInterface{
 					&ec2.InstanceNetworkInterface{
 						PrivateIpAddresses: []*ec2.InstancePrivateIpAddress{
 							&ec2.InstancePrivateIpAddress{
 								PrivateIpAddress: aws.String("10.0.0.2"),
+								PrivateDnsName:   aws.String("test2.example.internal"),
 							},
 						},
 					},
@@ -1437,9 +1448,11 @@ func TestAwsInstanceToHost(t *testing.T) {
 						PrivateIpAddresses: []*ec2.InstancePrivateIpAddress{
 							&ec2.InstancePrivateIpAddress{
 								Association: &ec2.InstanceNetworkInterfaceAssociation{
-									PublicIp: aws.String("1.1.1.1"),
+									PublicIp:      aws.String("1.1.1.1"),
+									PublicDnsName: aws.String("test.example.com"),
 								},
 								PrivateIpAddress: aws.String("10.0.0.1"),
+								PrivateDnsName:   aws.String("test.example.internal"),
 							},
 						},
 					},
@@ -1448,6 +1461,7 @@ func TestAwsInstanceToHost(t *testing.T) {
 			expected: &pb.ListHostsResponseHost{
 				ExternalId:  "foobar",
 				IpAddresses: []string{"10.0.0.1", "1.1.1.1", "10.0.0.2"},
+				DnsNames:    []string{"test.example.internal", "test.example.com", "test2.example.internal"},
 			},
 		},
 		{
@@ -1455,15 +1469,19 @@ func TestAwsInstanceToHost(t *testing.T) {
 			instance: &ec2.Instance{
 				InstanceId:       aws.String("foobar"),
 				PrivateIpAddress: aws.String("10.0.0.1"),
+				PrivateDnsName:   aws.String("test.example.internal"),
 				PublicIpAddress:  aws.String("1.1.1.1"),
+				PublicDnsName:    aws.String("test.example.com"),
 				NetworkInterfaces: []*ec2.InstanceNetworkInterface{
 					&ec2.InstanceNetworkInterface{
 						PrivateIpAddresses: []*ec2.InstancePrivateIpAddress{
 							&ec2.InstancePrivateIpAddress{
 								Association: &ec2.InstanceNetworkInterfaceAssociation{
-									PublicIp: aws.String("1.1.1.2"),
+									PublicIp:      aws.String("1.1.1.2"),
+									PublicDnsName: aws.String("test2.example.com"),
 								},
 								PrivateIpAddress: aws.String("10.0.0.2"),
+								PrivateDnsName:   aws.String("test2.example.internal"),
 							},
 						},
 					},
@@ -1471,9 +1489,11 @@ func TestAwsInstanceToHost(t *testing.T) {
 						PrivateIpAddresses: []*ec2.InstancePrivateIpAddress{
 							&ec2.InstancePrivateIpAddress{
 								Association: &ec2.InstanceNetworkInterfaceAssociation{
-									PublicIp: aws.String("1.1.1.1"),
+									PublicIp:      aws.String("1.1.1.1"),
+									PublicDnsName: aws.String("test.example.com"),
 								},
 								PrivateIpAddress: aws.String("10.0.0.1"),
+								PrivateDnsName:   aws.String("test.example.internal"),
 							},
 						},
 					},
@@ -1482,6 +1502,7 @@ func TestAwsInstanceToHost(t *testing.T) {
 			expected: &pb.ListHostsResponseHost{
 				ExternalId:  "foobar",
 				IpAddresses: []string{"10.0.0.1", "1.1.1.1", "10.0.0.2", "1.1.1.2"},
+				DnsNames:    []string{"test.example.internal", "test.example.com", "test2.example.internal", "test2.example.com"},
 			},
 		},
 		{
@@ -1489,18 +1510,23 @@ func TestAwsInstanceToHost(t *testing.T) {
 			instance: &ec2.Instance{
 				InstanceId:       aws.String("foobar"),
 				PrivateIpAddress: aws.String("10.0.0.1"),
+				PrivateDnsName:   aws.String("test.example.internal"),
 				PublicIpAddress:  aws.String("1.1.1.1"),
+				PublicDnsName:    aws.String("test.example.com"),
 				NetworkInterfaces: []*ec2.InstanceNetworkInterface{
 					&ec2.InstanceNetworkInterface{
 						PrivateIpAddresses: []*ec2.InstancePrivateIpAddress{
 							&ec2.InstancePrivateIpAddress{
 								Association: &ec2.InstanceNetworkInterfaceAssociation{
-									PublicIp: aws.String("1.1.1.1"),
+									PublicIp:      aws.String("1.1.1.1"),
+									PublicDnsName: aws.String("test.example.com"),
 								},
 								PrivateIpAddress: aws.String("10.0.0.1"),
+								PrivateDnsName:   aws.String("test.example.internal"),
 							},
 							&ec2.InstancePrivateIpAddress{
 								PrivateIpAddress: aws.String("10.0.0.2"),
+								PrivateDnsName:   aws.String("test2.example.internal"),
 							},
 						},
 					},
@@ -1509,6 +1535,7 @@ func TestAwsInstanceToHost(t *testing.T) {
 			expected: &pb.ListHostsResponseHost{
 				ExternalId:  "foobar",
 				IpAddresses: []string{"10.0.0.1", "1.1.1.1", "10.0.0.2"},
+				DnsNames:    []string{"test.example.internal", "test.example.com", "test2.example.internal"},
 			},
 		},
 		{
@@ -1516,7 +1543,9 @@ func TestAwsInstanceToHost(t *testing.T) {
 			instance: &ec2.Instance{
 				InstanceId:       aws.String("foobar"),
 				PrivateIpAddress: aws.String("10.0.0.1"),
+				PrivateDnsName:   aws.String("test.example.internal"),
 				PublicIpAddress:  aws.String("1.1.1.1"),
+				PublicDnsName:    aws.String("test.example.com"),
 				NetworkInterfaces: []*ec2.InstanceNetworkInterface{
 					&ec2.InstanceNetworkInterface{
 						PrivateIpAddresses: []*ec2.InstancePrivateIpAddress{
@@ -1537,6 +1566,7 @@ func TestAwsInstanceToHost(t *testing.T) {
 			expected: &pb.ListHostsResponseHost{
 				ExternalId:  "foobar",
 				IpAddresses: []string{"10.0.0.1", "1.1.1.1", "some::fake::address"},
+				DnsNames:    []string{"test.example.internal", "test.example.com"},
 			},
 		},
 	}


### PR DESCRIPTION
This adds DNS names to the output for host queries.

Hosts are discovered in private, then public order, first at the
top-level, and then through attached network interfaces. This mirrors
the discovery order of IP addresses.