### PR TITLE
Update README to have full, correct examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ client secret in use by this plugin.
 
 ## Getting Started
 
+Refer to [Attributes and Secrets](#attributes-and-secrets) for more detail on
+configuration options for host catalogs and sets.
+
 To create a host catalog (using default scope created by `boundary dev`):
 
 ```
@@ -41,9 +44,9 @@ boundary host-catalogs create plugin \
  -secret secret_access_key='SECRET'
 ```
 
-To create a host set, filtering the host set based on tag keys `foo` and `bar`,
-ensuring that any targets set to this host set only connect to external
-addresses in the `54.0.0.0/8` class A subnet:
+To create a host set, filtering the host set based on tag keys `foo` or `bar`
+(either tag can be present), ensuring that any targets set to this host set only
+connect to external addresses in the `54.0.0.0/8` class A subnet:
 
 ```
 boundary host-sets create plugin \
@@ -51,6 +54,31 @@ boundary host-sets create plugin \
  -name "Example Plugin-Based Host Set" \
  -description "Description for plugin-based host set" \
  -attr filters=tag-key=foo,bar \
+ -preferred-endpoint "cidr:54.0.0.0/8"
+```
+
+As above, but instances must have both tags (both `foo` and `bar` *must* be
+present):
+
+```
+boundary host-sets create plugin \
+ -host-catalog-id HOST_CATALOG_ID \
+ -name "Example Plugin-Based Host Set" \
+ -description "Description for plugin-based host set" \
+ -attr filters=tag-key=foo \
+ -attr filters=tag-key=bar \
+ -preferred-endpoint "cidr:54.0.0.0/8"
+```
+
+As above, but matching on tag key and launch date:
+
+```
+boundary host-sets create plugin \
+ -host-catalog-id HOST_CATALOG_ID \
+ -name "Example Plugin-Based Host Set" \
+ -description "Description for plugin-based host set" \
+ -attr filters=tag-key=foo \
+ -attr filters=launch-time=2022-01-04T* \
  -preferred-endpoint "cidr:54.0.0.0/8"
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,34 @@ given credentials will be used to create a new credential, and then the given
 credential will be revoked. In this way, after rotation, only Boundary knows the
 client secret in use by this plugin.
 
+## Getting Started
+
+To create a host catalog (using default scope created by `boundary dev`):
+
+```
+boundary host-catalogs create plugin \
+ -scope-id p_1234567890 \
+ -name "Example Plugin-Based Host Catalog" \
+ -description "Description for plugin-based host catalog" \
+ -plugin-name aws \
+ -attr region=REGION \
+ -secret access_key_id='KEY' \
+ -secret secret_access_key='SECRET'
+```
+
+To create a host set, filtering the host set based on tag keys `foo` and `bar`,
+ensuring that any targets set to this host set only connect to external
+addresses in the `54.0.0.0/8` class A subnet:
+
+```
+boundary host-sets create plugin \
+ -host-catalog-id HOST_CATALOG_ID \
+ -name "Example Plugin-Based Host Set" \
+ -description "Description for plugin-based host set" \
+ -attr filters=tag-key=foo,bar \
+ -preferred-endpoint "cidr:54.0.0.0/8"
+```
+
 ## Required IAM Privileges
 
 The following IAM privileges, at the very least, are required to be attached to
@@ -97,13 +125,3 @@ The following attributes are valid on an AWS host Set resource:
   a comma-separated list. For a list of filter options, check out
   [describe-instances in the AWS CLI
   reference](https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instances.html).
-
-#### Supplying Filters on the Boundary CLI
-
-As `filters` is part of a host set's attributes and may contain dashes which are
-not identifier-friendly, it's recommended you that supply attributes for AWS
-host sets as a full JSON string. Example:
-
-```
-boundary host-sets create plugin -host-catalog-id hc_1234567890 --attributes '{"filters":{"tag-name":["foo"]}}'
-```


### PR DESCRIPTION
This updates the README to have full examples for both host set and host
catalog creation, and also corrects an incorrect example in the JSON
example (tag-name was supposed to be tag-key).

Additionally, I've removed the JSON example as it's no longer needed as
the CLI corrects accepts filter names with dashes with the work
performed in #2 and #4.