### PR TITLE
Add region into IAM clients as well as EC2 clients

### DIFF
--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -651,7 +651,7 @@ func TestPluginOnCreateSetErr(t *testing.T) {
 					awsutil.MockOptionErr(errors.New(testOptionErr)),
 				}),
 			},
-			expectedErrContains: fmt.Sprintf("error getting EC2 client: error getting AWS session: error reading options in NewCredentialsConfig: %s", testOptionErr),
+			expectedErrContains: fmt.Sprintf("error getting EC2 client: error getting AWS session when fetching EC2 client: error reading options in NewCredentialsConfig: %s", testOptionErr),
 			expectedErrCode:     codes.InvalidArgument,
 		},
 		{
@@ -950,7 +950,7 @@ func TestPluginOnUpdateSetErr(t *testing.T) {
 					awsutil.MockOptionErr(errors.New(testOptionErr)),
 				}),
 			},
-			expectedErrContains: fmt.Sprintf("error getting EC2 client: error getting AWS session: error reading options in NewCredentialsConfig: %s", testOptionErr),
+			expectedErrContains: fmt.Sprintf("error getting EC2 client: error getting AWS session when fetching EC2 client: error reading options in NewCredentialsConfig: %s", testOptionErr),
 			expectedErrCode:     codes.InvalidArgument,
 		},
 		{
@@ -1248,7 +1248,7 @@ func TestPluginListHostsErr(t *testing.T) {
 					awsutil.MockOptionErr(errors.New(testOptionErr)),
 				}),
 			},
-			expectedErrContains: fmt.Sprintf("error getting EC2 client: error getting AWS session: error reading options in NewCredentialsConfig: %s", testOptionErr),
+			expectedErrContains: fmt.Sprintf("error getting EC2 client: error getting AWS session when fetching EC2 client: error reading options in NewCredentialsConfig: %s", testOptionErr),
 			expectedErrCode:     codes.InvalidArgument,
 		},
 		{


### PR DESCRIPTION
I believe this will fix https://github.com/hashicorp/boundary/issues/2233

I can't test on GovCloud, but I was able to verify that the end-to-end tests run correctly with these changes with both `us-east-1` and `us-west-1`.