### PR TITLE
feat(ci): Update GitHub Actions Runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: [self-hosted, ondemand, linux, small]
+    runs-on: ubuntu-latest
     env:
       GO111MODULE: on
     permissions:


### PR DESCRIPTION
[Ticket: ICU-9567](https://hashicorp.atlassian.net/browse/ICU-9567)

This PR fixes the CI failures due to missing shared runners by changing the self-hosted runners to a github-hosted one (i.e. `ubuntu-latest`).

Reasons:
Self-hosted runners are only available for and shared with internal/private repos.